### PR TITLE
Android : better promises handling + bonuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ buck-out/
 
 # generated
 lib
+
+# Local history vs code plugin
+.history/

--- a/android/src/main/java/com/audiowaveform/AudioPlayer.kt
+++ b/android/src/main/java/com/audiowaveform/AudioPlayer.kt
@@ -92,13 +92,13 @@ class AudioPlayer(
                     }
                 }
                 override fun onPlayerError(error: PlaybackException) {
-                    promise.reject("preparePlayer-onPlayerError", error.message)
+                    promise.reject("preparePlayer onPlayerError", error.message)
                 }
             }
 
             player.addListener(playerListener)
         } else {
-            promise.reject("preparePlayer-error", "path to audio file or unique key can't be null")
+            promise.reject("preparePlayer Error", "path to audio file or unique key can't be null")
         }
     }
 
@@ -181,7 +181,7 @@ class AudioPlayer(
                 override fun onFinish() {}
             }.start()
         } catch(err: JavascriptException) {
-            throw Exception("startListening-error", err)
+            throw Exception("startListening Error", err)
         }
     }
 

--- a/android/src/main/java/com/audiowaveform/AudioRecorder.kt
+++ b/android/src/main/java/com/audiowaveform/AudioRecorder.kt
@@ -22,35 +22,15 @@ class AudioRecorder {
     private var useLegacyNormalization = false
     private var isRecording = false
 
-    private fun isPermissionGranted(activity: Activity?): Int? {
-        return activity?.let { ActivityCompat.checkSelfPermission(it, permissions[0]) }
-    }
+    private fun isPermissionGranted(activity: Activity?): Int? = activity?.let { ActivityCompat.checkSelfPermission(it, permissions[0]) }
 
-    fun checkPermission(activity: Activity?, promise: Promise): String {
-        val permissionResponse = isPermissionGranted(activity)
-        if (permissionResponse === PackageManager.PERMISSION_GRANTED) {
-            promise.resolve("granted")
-            return "granted"
-        } else {
-            promise.resolve("denied")
-            return "denied"
-        }
-    }
+    fun checkPermission(activity: Activity?): String = if (isPermissionGranted(activity) == PackageManager.PERMISSION_GRANTED) "granted" else "denied"
 
-    fun getPermission(activity: Activity?, promise: Promise): String {
-        val permissionResponse = isPermissionGranted(activity)
-        if (permissionResponse === PackageManager.PERMISSION_GRANTED) {
-            promise.resolve("granted");
-            return "granted"
-        } else {
-            activity?.let {
-                ActivityCompat.requestPermissions(
-                    it, permissions,
-                    RECORD_AUDIO_REQUEST_CODE
-                )
-            }
-            return "denied"
-        }
+    fun getPermission(activity: Activity?): String {
+        if (isPermissionGranted(activity) == PackageManager.PERMISSION_GRANTED) return "granted"
+
+        activity?.let { ActivityCompat.requestPermissions(it, permissions, RECORD_AUDIO_REQUEST_CODE) }
+        return "denied"
     }
 
     fun getDecibel(recorder: MediaRecorder?): Double? {
@@ -133,7 +113,7 @@ class AudioRecorder {
                 val tempArrayForCommunication : MutableList<String> = mutableListOf()
                 val duration = getDuration(path)
                 tempArrayForCommunication.add(path)
-                tempArrayForCommunication.add(duration.toString())
+                tempArrayForCommunication.add(duration)
                 promise.resolve(Arguments.fromList(tempArrayForCommunication))
             } else {
                 promise.reject("Error", "Recorder is not recording or has already been stopped")

--- a/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
+++ b/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
@@ -49,7 +49,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             promise.resolve(audioRecorder.checkPermission(currentActivity))
         }
         catch (err: Exception) {
-            promise.reject("checkHasAudioRecorderPermission-error", err.toString())
+            promise.reject("checkHasAudioRecorderPermission Error", err.toString())
         }
     }
 
@@ -59,7 +59,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             promise.resolve(audioRecorder.getPermission(currentActivity))
         }
         catch (err: Exception) {
-            promise.reject("getAudioRecorderPermission-error", err.toString())
+            promise.reject("getAudioRecorderPermission Error", err.toString())
         }
     }
 
@@ -76,7 +76,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             promise.resolve(audioRecorder.getDecibel(recorder))
         }
         catch (err: Exception) {
-            promise.reject("getDecibel-error", err.toString())
+            promise.reject("getDecibel Error", err.toString())
         }
     }
 
@@ -138,7 +138,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             }
 
             val path = obj.getString(Constants.path)
-            val key = getPlayerKeyOrReject(obj, promise, "preparePlayer-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "preparePlayer Error") ?: return
             val frequency = obj.getInt(Constants.updateFrequency)
             val volume = obj.getInt(Constants.volume)
             val progress = if (!obj.hasKey(Constants.progress) || obj.isNull(Constants.progress)) {
@@ -149,7 +149,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
 
             initPlayer(key).preparePlayer(path, volume, getUpdateFrequency(frequency), progress, promise)
         } catch (err: Exception) {
-            promise.reject("preparePlayer-error", err.toString())
+            promise.reject("preparePlayer Error", err.toString())
         }
     }
 
@@ -157,22 +157,22 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
     fun startPlayer(obj: ReadableMap, promise: Promise) {
         try {
             val finishMode = obj.getInt(Constants.finishMode)
-            val key = getPlayerKeyOrReject(obj, promise, "startPlayer-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "startPlayer Error") ?: return
             val speed = obj.getDouble(Constants.speed)
 
-            getPlayerOrReject(key, promise, "startPlayer-error")?.let { player ->
+            getPlayerOrReject(key, promise, "startPlayer Error")?.let { player ->
                 promise.resolve(player.start(finishMode, speed.toFloat()))
             }
         }
         catch (err: Exception) {
-            promise.reject("startPlayer-error", err.toString())
+            promise.reject("startPlayer Error", err.toString())
         }
     }
 
     @ReactMethod
     fun stopPlayer(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "stopPlayer-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "stopPlayer Error") ?: return
 
             audioPlayers[key]?.let { player ->
                 player.stop()
@@ -180,20 +180,20 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             }
             promise.resolve(true)
         } catch (err: Exception) {
-          promise.reject("stopPlayer-error", err.toString())
+          promise.reject("stopPlayer Error", err.toString())
         }
     }
 
     @ReactMethod
     fun pausePlayer(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "pausePlayer-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "pausePlayer Error") ?: return
 
-            getPlayerOrReject(key, promise, "pausePlayer-error")?.let { player ->
+            getPlayerOrReject(key, promise, "pausePlayer Error")?.let { player ->
                 promise.resolve(player.pause())
             }
         } catch (err: Exception) {
-            promise.reject("pausePlayer-error", err.toString())
+            promise.reject("pausePlayer Error", err.toString())
         }
     }
 
@@ -201,7 +201,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
     fun seekToPlayer(obj: ReadableMap, promise: Promise) {
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val key = getPlayerKeyOrReject(obj, promise, "seekToPlayer-error") ?: return
+                val key = getPlayerKeyOrReject(obj, promise, "seekToPlayer Error") ?: return
                 val progress = obj.getInt(Constants.progress)
 
                 val sought = audioPlayers[key]?.seekToPosition(progress.toLong())
@@ -215,50 +215,50 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             }
         }
         catch (err: Exception) {
-            promise.reject("seekToPlayer-error", "Unable to seek player")
+            promise.reject("seekToPlayer Error", "Unable to seek player")
         }
     }
 
     @ReactMethod
     fun setVolume(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "setVolume-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "setVolume Error") ?: return
             val volume = obj.getInt(Constants.volume)
 
-            getPlayerOrReject(key, promise, "setVolume-error")?.let { player ->
+            getPlayerOrReject(key, promise, "setVolume Error")?.let { player ->
                 promise.resolve(player.setVolume(volume.toFloat()))
             }
         } catch (err: Exception) {
-            promise.reject("setVolume-error", err.toString())
+            promise.reject("setVolume Error", err.toString())
         }
     }
 
     @ReactMethod
     fun getDuration(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "getDuration-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "getDuration Error") ?: return
             val duration = obj.getInt(Constants.durationType)
             val type = if (duration == 0) DurationType.Current else DurationType.Max
 
-            getPlayerOrReject(key, promise, "getDuration-error")?.let { player ->
+            getPlayerOrReject(key, promise, "getDuration Error")?.let { player ->
                 promise.resolve(player.getDuration(type).toString())
             }
         } catch (err: Exception) {
-            promise.reject("getDuration-error", err.toString())
+            promise.reject("getDuration Error", err.toString())
         }
     }
 
     @ReactMethod
     fun extractWaveformData(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "extractWaveformData-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "extractWaveformData Error") ?: return
             val path = obj.getString(Constants.path)
             val noOfSamples = obj.getInt(Constants.noOfSamples)
 
             createOrUpdateExtractor(key, noOfSamples, path, promise)
         }
         catch (err: Error) {
-            promise.reject("extractWaveformData-error", err.toString())
+            promise.reject("extractWaveformData Error", err.toString())
         }
     }
 
@@ -272,14 +272,14 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             promise.resolve(true)
         }
         catch (err:Exception) {
-            promise.reject("stopAllPlayers-error", "Error while stopping all players")
+            promise.reject("stopAllPlayers Error", "Error while stopping all players")
         }
     }
 
     @ReactMethod
     fun setPlaybackSpeed(obj: ReadableMap, promise: Promise) {
         try {
-            val key = getPlayerKeyOrReject(obj, promise, "setPlaybackSpeed-error") ?: return
+            val key = getPlayerKeyOrReject(obj, promise, "setPlaybackSpeed Error") ?: return
             // If the key doesn't exist or if the value is null or undefined, set default speed to 1.0
             val speed = if (!obj.hasKey(Constants.speed) || obj.isNull(Constants.speed)) {
                 1.0f // Set default speed to 1.0 if null, undefined, or missing
@@ -291,7 +291,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
 
             promise.resolve(succeed ?: false)
         } catch (err: Exception) {
-            promise.reject("setPlaybackSpeed-error", err.toString())
+            promise.reject("setPlaybackSpeed Error", err.toString())
         }
     }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -375,10 +375,10 @@ PODS:
   - React-jsinspector (0.72.7)
   - React-logger (0.72.7):
     - glog
-  - react-native-audio-waveform (1.0.0):
+  - react-native-audio-waveform (2.1.1):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - react-native-safe-area-context (4.9.0):
+  - react-native-safe-area-context (4.11.0):
     - React-Core
   - React-NativeModulesApple (0.72.7):
     - hermes-engine
@@ -494,7 +494,7 @@ PODS:
     - React-Core
   - RNFS (2.20.0):
     - React-Core
-  - RNGestureHandler (2.14.0):
+  - RNGestureHandler (2.19.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - SocketRocket (0.6.1)
@@ -714,8 +714,8 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c49502e5d02112247ee4526bc3ccfc891ae3eb9b
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
-  react-native-audio-waveform: 7cdb6e4963eeae907240396975b9c79713591758
-  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
+  react-native-audio-waveform: 351a96a6b413c70b096347c880910dc35b6367b7
+  react-native-safe-area-context: 851c62c48dce80ccaa5637b6aa5991a1bc36eca9
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a
   React-perflogger: 31ea61077185eb1428baf60c0db6e2886f141a5a
   React-RCTActionSheet: 392090a3abc8992eb269ef0eaa561750588fc39d
@@ -735,7 +735,7 @@ SPEC CHECKSUMS:
   ReactCommon: 5f704096ccf7733b390f59043b6fa9cc180ee4f6
   rn-fetch-blob: f065bb7ab7fb48dd002629f8bdcb0336602d3cba
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNGestureHandler: 32a01c29ecc9bb0b5bf7bc0a33547f61b4dc2741
+  RNGestureHandler: 7ad14a6c7b491add489246611d324f10009083ac
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -124,13 +124,10 @@ const RenderListItem = React.memo(
               onError={error => {
                 console.log(error, 'we are in example');
               }}
-              onCurrentProgressChange={(currentProgress, songDuration) => {
-                console.log(
-                  'currentProgress ',
-                  currentProgress,
-                  'songDuration ',
-                  songDuration
-                );
+              onCurrentProgressChange={(_currentProgress, _songDuration) => {
+                // console.log(
+                //   `currentProgress ${currentProgress}, songDuration ${songDuration}`
+                // );
               }}
               onChangeWaveformLoadState={state => {
                 setIsLoading(state);

--- a/example/src/constants/Audios.ts
+++ b/example/src/constants/Audios.ts
@@ -69,6 +69,11 @@ const audioAssetArray = [
   'file_example_mp3_15s.mp3',
 ];
 
+const getRecordedAudio = async (): Promise<string[]> => {
+  const items = await fs.readDir(fs.CachesDirectoryPath)
+  return items.filter(item =>  item.path.endsWith('.m4a')).map(item => item.path)
+}
+
 /**
  * Generate a list of file objects with information about successfully copied files (Android)
  * or all files (iOS).
@@ -78,8 +83,14 @@ export const generateAudioList = async (): Promise<ListItem[]> => {
   const audioAssets = await copyFilesToNativeResources();
 
   // Generate the final list based on the copied or available files
-  return audioAssets?.map?.((value, index) => ({
+  const providedAudioFilePaths = audioAssets?.map?.((value) => `${filePath}/${value}`);
+
+  const recordedAudioFilePaths = await getRecordedAudio();
+
+  const listItems = ['invalid_file_example.mp3', ...providedAudioFilePaths, ...recordedAudioFilePaths].map((value, index) => ({
     fromCurrentUser: index % 2 !== 0,
-    path: `${filePath}/${value}`,
-  }));
+    path: value,
+  }))
+
+  return listItems;
 };

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -55,7 +55,7 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
     onPlayerStateChange,
     onRecorderStateChange,
     onPanStateChange = () => {},
-    onError = () => {},
+    onError = (_err: unknown) => {},
     onCurrentProgressChange = () => {},
     candleHeightScale = 3,
     onChangeWaveformLoadState,

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -119,43 +119,30 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
 
   const preparePlayerForPath = async (progress?: number) => {
     if (!isNil(path) && !isEmpty(path)) {
-      try {
-        const prepare = await preparePlayer({
-          path,
-          playerKey: `PlayerFor${path}`,
-          updateFrequency: UpdateFrequency.medium,
-          volume: volume,
-          progress,
-        });
-        return Promise.resolve(prepare);
-      } catch (err) {
-        return Promise.reject(err);
-      }
-    } else {
-      return Promise.reject(
-        new Error(`Can not start player for path: ${path}`)
-      );
+      return await preparePlayer({
+        path,
+        playerKey: `PlayerFor${path}`,
+        updateFrequency: UpdateFrequency.medium,
+        volume: volume,
+        progress,
+      });
     }
+
+    throw new Error(`Can not start player for path: ${path}`);
   };
 
   const getAudioDuration = async () => {
-    try {
-      const duration = await getDuration({
-        playerKey: `PlayerFor${path}`,
-        durationType: DurationType.max,
-      });
-      if (!isNil(duration)) {
-        const audioDuration = Number(duration);
-        setSongDuration(audioDuration > 0 ? audioDuration : 0);
-        return Promise.resolve(audioDuration);
-      } else {
-        return Promise.reject(
-          new Error(`Could not get duration for path: ${path}`)
-        );
-      }
-    } catch (err) {
-      return Promise.reject(err);
+    const duration = await getDuration({
+      playerKey: `PlayerFor${path}`,
+      durationType: DurationType.max,
+    });
+    if (!isNil(duration)) {
+      const audioDuration = Number(duration);
+      setSongDuration(audioDuration > 0 ? audioDuration : 0);
+      return audioDuration;
     }
+
+    throw new Error(`Could not get duration for path: ${path}`);
   };
 
   const preparePlayerAndGetDuration = async () => {
@@ -169,7 +156,7 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
       }
     } catch (err) {
       console.error(err);
-      (onError as Function)(err);
+      onError(err);
     }
   };
 
@@ -192,14 +179,12 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
           }
         }
       } catch (err) {
-        (onError as Function)(err);
+        onError(err);
         (onChangeWaveformLoadState as Function)?.(false);
         console.error(err);
       }
     } else {
-      (onError as Function)(
-        `Can not find waveform for mode ${mode} path: ${path}`
-      );
+      onError(`Can not find waveform for mode ${mode} path: ${path}`);
       console.error(`Can not find waveform for mode ${mode} path: ${path}`);
     }
   };

--- a/src/hooks/useAudioPlayer.tsx
+++ b/src/hooks/useAudioPlayer.tsx
@@ -17,30 +17,51 @@ import {
   type IStopPlayer,
 } from '../types';
 
+let nbOfPromises = 0;
+
+const logPromise = async (promise: any, promiseName: string) => {
+  try {
+    nbOfPromises++;
+    console.log(`Promise ${promiseName} has been called`);
+    return await promise();
+  } finally {
+    nbOfPromises--;
+    console.log(`Promise ${promiseName} has finished`);
+    console.log(`Number of promises remaining: ${nbOfPromises}`);
+  }
+};
+
 export const useAudioPlayer = () => {
   const audioPlayerEmitter = new NativeEventEmitter(
     NativeModules.AudioWaveformsEventEmitter
   );
 
-  const extractWaveformData = (args: IExtractWaveform) =>
-    AudioWaveform.extractWaveformData(args);
+  const extractWaveformData = (args: IExtractWaveform): Promise<number[][]> =>
+    logPromise(() => AudioWaveform.extractWaveformData(args), 'extractor');
 
   const preparePlayer = (args: IPreparePlayer) =>
-    AudioWaveform.preparePlayer(args);
+    logPromise(() => AudioWaveform.preparePlayer(args), 'preparePlayer');
 
-  const playPlayer = (args: IStartPlayer) => AudioWaveform.startPlayer(args);
+  const playPlayer = (args: IStartPlayer) =>
+    logPromise(() => AudioWaveform.startPlayer(args), 'playPlayer');
 
-  const pausePlayer = (args: IPausePlayer) => AudioWaveform.pausePlayer(args);
+  const pausePlayer = (args: IPausePlayer) =>
+    logPromise(() => AudioWaveform.pausePlayer(args), 'pausePlayer');
 
-  const stopPlayer = (args: IStopPlayer) => AudioWaveform.stopPlayer(args);
+  const stopPlayer = (args: IStopPlayer) =>
+    logPromise(() => AudioWaveform.stopPlayer(args), 'stopPlayer');
 
-  const seekToPlayer = (args: ISeekPlayer) => AudioWaveform.seekToPlayer(args);
+  const seekToPlayer = (args: ISeekPlayer) =>
+    logPromise(() => AudioWaveform.seekToPlayer(args), 'seekToPlayer');
 
-  const setVolume = (args: ISetVolume) => AudioWaveform.setVolume(args);
+  const setVolume = (args: ISetVolume) =>
+    logPromise(() => AudioWaveform.setVolume(args), 'setVolume');
 
-  const stopAllPlayers = () => AudioWaveform.stopAllPlayers();
+  const stopAllPlayers = () =>
+    logPromise(AudioWaveform.stopAllPlayers, 'stopAllPlayers');
 
-  const getDuration = (args: IGetDuration) => AudioWaveform.getDuration(args);
+  const getDuration = (args: IGetDuration) =>
+    logPromise(() => AudioWaveform.getDuration(args), 'getDuration');
 
   const onDidFinishPlayingAudio = (
     callback: (result: IDidFinishPlayings) => void
@@ -74,11 +95,10 @@ export const useAudioPlayer = () => {
     );
 
   const setPlaybackSpeed = (args: ISetPlaybackSpeed) =>
-    AudioWaveform.setPlaybackSpeed(args);
+    logPromise(() => AudioWaveform.setPlaybackSpeed(args), 'setPlaybackSpeed');
 
-  const markPlayerAsUnmounted = () => {
-    AudioWaveform.markPlayerAsUnmounted();
-  };
+  const markPlayerAsUnmounted = () =>
+    logPromise(AudioWaveform.markPlayerAsUnmounted, 'markPlayerAsUnmounted');
 
   return {
     extractWaveformData,

--- a/src/types/AudioWaveformTypes.ts
+++ b/src/types/AudioWaveformTypes.ts
@@ -33,9 +33,9 @@ export interface IPreparePlayer extends IPlayerKey, IPlayerPath {
 }
 
 export interface IStartPlayer extends IPlayerKey {
-  finishMode?: FinishMode;
-  speed?: number;
-  path?: string;
+  finishMode: FinishMode;
+  speed: number;
+  path: string;
 }
 
 export interface IStopPlayer extends IPlayerKey {}


### PR DESCRIPTION
Some leftover code fixing some other leaking promises + other code refactoring

Highlights:
- Keeping promises inside `AudioWaveformModule` helps to ensure promises are resolved correctly
- Moving promises out of `AudioPlayer` for a leaner class and not "react-native" tainted
- Doing try-catch so the app does not crash when having an exception

Bonus: 
- I added a feature in the example to list recorded audio after the app reboot!
- I removed the deprecation of `onPlayerStateChanged` in favour of `onPlaybackStateChanged`
- I reviewed the weird handling of `onError` and simplified it
- In JS, I removed a few `Promise.resolve` and `Promise.reject` combined with try-catch that are useless and can be simplified by returning the value directly or throwing an error since the method is already `async`
- I fixed a case where the promise leaks when the path in the `preparePlayer` is wrong. If we play a file with an invalid path, the player never gets ready and gets stuck idle. Since `player.prepare()` should move it out of `idle`, if it stays in `idle`, there is a problem, and the promise is rejected.
- I set props of `IStartPlayer` mandatory else; I test it, and passing no value crashes the android, so there are no optional
- I removed the `await preparePlayerForPath();` inside the `onDidFinishPlayingAudio` since this one is circular, where you trigger the player's end but recreate it immediately. Also, after removal, it still works
- Code simplification by using standard functions to validate the player key string and the audio player in the hash map

Let me know what you think!

Note: I may need to remove my logger `logPromise` tracking the leaking promises before you merge!