### PR TITLE
[iOS][AudioPlayer] Fix AVAudioPlayer volume default value

### DIFF
--- a/ios/AudioPlayer.swift
+++ b/ios/AudioPlayer.swift
@@ -41,7 +41,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
       do {
         player = try AVAudioPlayer(contentsOf: audioUrl!)
         player?.prepareToPlay()
-        player?.volume = Float(volume ?? 100.0)
+        player?.volume = Float(volume ?? 1.0)
         player?.currentTime = Double(time / 1000)
         player?.enableRate = true
         resolve(true)


### PR DESCRIPTION
As stated in avfaudio/avaudioplayer documentation, volume value must be a range [0.0, 1.0] Source => https://developer.apple.com/documentation/avfaudio/avaudioplayer/1389330-volume

This is following this closed but not fixed issue: https://github.com/SimformSolutionsPvtLtd/react-native-audio-waveform/issues/49

Phone:
    iPhone 13
    iOS 17.5.1

Bluetooth Device:
    JBL Charge 3
