### PR TITLE
fix: use lodash-es for better tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@testing-library/react-native": "^9.0.0",
     "@tsconfig/react-native": "^2.0.2",
     "@types/jest": "^27.4.0",
-    "@types/lodash": "^4.14.202",
+    "@types/lodash-es": "^4.14.202",
     "@types/react-native": "^0.69.5",
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
@@ -110,6 +110,6 @@
     ]
   },
   "dependencies": {
-    "lodash": "^4.17.21"
+    "lodash-es": "^4.17.21"
   }
 }

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -1,4 +1,6 @@
-import { clamp, floor, head, isEmpty, isNil } from 'lodash';
+import clamp from 'lodash-es/clamp';
+import isEmpty from 'lodash-es/isEmpty';
+import isNil from 'lodash-es/isNil';
 import React, {
   forwardRef,
   useEffect,
@@ -37,6 +39,8 @@ import {
   type LiveWaveform,
   type StaticWaveform,
 } from './WaveformTypes';
+import head from 'lodash-es/head';
+import floor from 'lodash-es/floor';
 
 export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
   const {


### PR DESCRIPTION
Our project counts a lot on `lodash-es` for better tree shaking. Since this lib aim mobile project it would interesting to have it