### PR TITLE
fix: Leaking promise on getDuration + `NSError()` crash in rejected promises

### DIFF
--- a/ios/AudioPlayer.swift
+++ b/ios/AudioPlayer.swift
@@ -87,7 +87,7 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
     EventEmitter.sharedInstance.dispatch(name: withName, body: body)
   }
   
-    func startPlyer(_ finishMode: Int?, speed: Float, result: RCTPromiseResolveBlock) {
+    func startPlayer(_ finishMode: Int?, speed: Float, result: RCTPromiseResolveBlock) {
       if(finishMode != nil && finishMode == 0) {
         self.finishMode = FinishMode.loop
       } else if(finishMode != nil && finishMode == 1) {

--- a/ios/AudioRecorder.swift
+++ b/ios/AudioRecorder.swift
@@ -49,7 +49,7 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
    
     if (path == nil) {
       guard let newPath = self.createAudioRecordPath(fileNameFormat: fileNameFormat) else {
-        reject(Constants.audioWaveforms, "Failed to initialise file URL", NSError())
+        reject(Constants.audioWaveforms, "Failed to initialise file URL", nil)
         return
       }
       audioUrl = newPath
@@ -62,7 +62,7 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
       try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playAndRecord, options: options)
       try AVAudioSession.sharedInstance().setActive(true)
       guard let newPath = audioUrl else {
-        reject(Constants.audioWaveforms, "Failed to initialise file URL", NSError())
+        reject(Constants.audioWaveforms, "Failed to initialise file URL", nil)
         return
       }
       audioRecorder = try AVAudioRecorder(url: newPath, settings: settings as [String : Any])
@@ -116,7 +116,7 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
         resolve([asset.url.absoluteString,Int(recordedDuration.seconds * 1000).description])
       }
     } else {
-      reject(Constants.audioWaveforms, "Failed to stop recording", NSError())
+      reject(Constants.audioWaveforms, "Failed to stop recording", nil)
     }
     audioRecorder = nil
   }

--- a/ios/AudioWaveform.swift
+++ b/ios/AudioWaveform.swift
@@ -105,7 +105,7 @@ class AudioWaveform: RCTEventEmitter {
     if(key != nil) {
       createOrUpdateExtractor(playerKey: key!, path: path, noOfSamples: noOfSamples, resolve: resolve, rejecter: reject)
     } else {
-      reject(Constants.audioWaveforms,"Can not get waveform data",NSError())
+      reject(Constants.audioWaveforms,"Can not get waveform data",nil)
     }
   }
   
@@ -114,7 +114,7 @@ class AudioWaveform: RCTEventEmitter {
       do {
         let audioUrl = URL.init(string: path!)
         if(audioUrl == nil){
-          reject(Constants.audioWaveforms, "Failed to initialise Url from provided audio file If path contains `file://` try removing it", NSError())
+          reject(Constants.audioWaveforms, "Failed to initialise Url from provided audio file If path contains `file://` try removing it", nil)
         }
         let newExtractor = try WaveformExtractor(url: audioUrl!, channel: self, resolve: resolve, rejecter: reject)
         extractors[playerKey] = newExtractor
@@ -130,7 +130,7 @@ class AudioWaveform: RCTEventEmitter {
         reject(Constants.audioWaveforms, "Failed to decode audio file", e)
       }
     } else {
-      reject(Constants.audioWaveforms, "Audio file path can't be empty or null", NSError())
+      reject(Constants.audioWaveforms, "Audio file path can't be empty or null", nil)
       
     }
   }
@@ -156,7 +156,7 @@ class AudioWaveform: RCTEventEmitter {
                                         resolver: resolve,
                                         rejecter: reject)
     } else {
-      reject(Constants.audioWaveforms, "Can not prepare player", NSError())
+      reject(Constants.audioWaveforms, "Can not prepare player", nil)
     }
   }
   
@@ -168,7 +168,7 @@ class AudioWaveform: RCTEventEmitter {
     if(key != nil){
         audioPlayers[key!]?.startPlyer(finishMode, speed: speed, result:resolve)
     } else {
-      reject(Constants.audioWaveforms, "Can not start player", NSError())
+      reject(Constants.audioWaveforms, "Can not start player", nil)
     }
   }
   
@@ -177,7 +177,7 @@ class AudioWaveform: RCTEventEmitter {
     if(key != nil){
       audioPlayers[key!]?.pausePlayer(result: resolve)
     } else {
-      reject(Constants.audioWaveforms, "Can not pause player, Player key is null", NSError())
+      reject(Constants.audioWaveforms, "Can not pause player, Player key is null", nil)
     }
   }
   
@@ -188,7 +188,7 @@ class AudioWaveform: RCTEventEmitter {
       audioPlayers[key!] = nil // Release the player after stopping it
       resolve(true)
     } else {
-      reject(Constants.audioWaveforms, "Can not stop player, Player key is null", NSError())
+      reject(Constants.audioWaveforms, "Can not stop player, Player key is null", nil)
     }
   }
   
@@ -197,7 +197,7 @@ class AudioWaveform: RCTEventEmitter {
     if(key != nil){
       audioPlayers[key!]?.seekTo(args?[Constants.progress] as? Double,resolve)
     } else {
-      reject(Constants.audioWaveforms, "Can not seek to postion, Player key is null", NSError())
+      reject(Constants.audioWaveforms, "Can not seek to postion, Player key is null", nil)
     }
   }
   
@@ -206,14 +206,14 @@ class AudioWaveform: RCTEventEmitter {
     if(key != nil){
       audioPlayers[key!]?.setVolume(args?[Constants.volume] as? Double,resolve)
     } else {
-      reject(Constants.audioWaveforms, "Can not set volume, Player key is null", NSError())
+      reject(Constants.audioWaveforms, "Can not set volume, Player key is null", nil)
     }
   }
   
   @objc func getDuration(_ args: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
     let type = args?[Constants.durationType] as? Int
     let key = args?[Constants.playerKey] as? String
-    if(key != nil){
+    if(key != nil && audioPlayers[key!] != nil){
       do{
         if(type == 0) {
           try audioPlayers[key!]?.getDuration(DurationType.Current,resolve)
@@ -224,7 +224,7 @@ class AudioWaveform: RCTEventEmitter {
         reject(Constants.audioWaveforms, "Failed to get duration", e)
       }
     } else {
-      reject(Constants.audioWaveforms, "Can not get duration", NSError())
+      reject(Constants.audioWaveforms, "Can not get duration", nil)
     }
   }
   
@@ -263,7 +263,7 @@ class AudioWaveform: RCTEventEmitter {
           let status =  audioPlayers[key!]?.setPlaybackSpeed(speed)
           resolve(status)
         } else {
-          reject(Constants.audioWaveforms, "Can not pause player, Player key is null", NSError())
+          reject(Constants.audioWaveforms, "Can not pause player, Player key is null", nil)
         }
     }
 }

--- a/ios/AudioWaveform.swift
+++ b/ios/AudioWaveform.swift
@@ -165,8 +165,8 @@ class AudioWaveform: RCTEventEmitter {
     let finishMode = args?[Constants.finishMode] as? Int
     let speed = (args?[Constants.speed] as? NSNumber)?.floatValue ?? 1.0
       
-    if(key != nil){
-        audioPlayers[key!]?.startPlyer(finishMode, speed: speed, result:resolve)
+    if(key != nil && audioPlayers[key!] != nil){
+        audioPlayers[key!]?.startPlayer(finishMode, speed: speed, result:resolve)
     } else {
       reject(Constants.audioWaveforms, "Can not start player", nil)
     }
@@ -174,7 +174,7 @@ class AudioWaveform: RCTEventEmitter {
   
   @objc func pausePlayer(_ args: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
     let key = args?[Constants.playerKey] as? String
-    if(key != nil){
+    if(key != nil && audioPlayers[key!] != nil){
       audioPlayers[key!]?.pausePlayer(result: resolve)
     } else {
       reject(Constants.audioWaveforms, "Can not pause player, Player key is null", nil)
@@ -194,7 +194,7 @@ class AudioWaveform: RCTEventEmitter {
   
   @objc func seekToPlayer(_ args: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
     let key = args?[Constants.playerKey] as? String
-    if(key != nil){
+    if(key != nil && audioPlayers[key!] != nil){
       audioPlayers[key!]?.seekTo(args?[Constants.progress] as? Double,resolve)
     } else {
       reject(Constants.audioWaveforms, "Can not seek to postion, Player key is null", nil)
@@ -203,7 +203,7 @@ class AudioWaveform: RCTEventEmitter {
   
   @objc func setVolume(_ args: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) -> Void {
     let key = args?[Constants.playerKey] as? String
-    if(key != nil){
+    if(key != nil && audioPlayers[key!] != nil){
       audioPlayers[key!]?.setVolume(args?[Constants.volume] as? Double,resolve)
     } else {
       reject(Constants.audioWaveforms, "Can not set volume, Player key is null", nil)


### PR DESCRIPTION
The promise is neither rejected nor resolved when calling `getDuration` on iOS with no audioPlayer in the hashMap.

Once fixed, I discovered that using `NSError()` when rejecting a promise crashes instead of finishing the promise action. Using `nil` instead fixes the issue, so I spread it everywhere.

`startPlayer`, `pausePlayer`, `seekToPlayer`, and `setVolume` also leaked the promise under the conditions when no player is in the hashMap.

