### PR TITLE
fix: stop only the current player and not all players

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -63,24 +63,31 @@ const RenderListItem = React.memo(
     const [isLoading, setIsLoading] = useState(true);
 
     const handlePlayStopAction = async () => {
-      if (currentPlayingRef == null) {
+      console.log('currentPlayingRef', currentPlayingRef);
+
+      let currentPlayer = currentPlayingRef?.current;
+
+      // If no player or if current player is stopped just start it!
+      if (
+        currentPlayer == null ||
+        currentPlayer.currentState === PlayerState.stopped
+      ) {
         currentPlayingRef = ref;
         await currentPlayingRef.current?.startPlayer({
           finishMode: FinishMode.stop,
         });
-      } else if (
-        currentPlayingRef.current?.currentState === PlayerState.playing
-      ) {
-        await currentPlayingRef?.current?.stopPlayer();
-        if (
-          currentPlayingRef.current.playerKey() !== ref?.current?.playerKey()
-        ) {
+      } else {
+        // Always stop current player if it was playing
+        if (currentPlayer.currentState === PlayerState.playing) {
+          await currentPlayingRef?.current?.stopPlayer();
+        }
+
+        // Start player only when it is a different one!
+        if (currentPlayer.playerKey() !== ref?.current?.playerKey()) {
           currentPlayingRef = ref;
           await currentPlayingRef.current?.startPlayer({
             finishMode: FinishMode.stop,
           });
-        } else {
-          currentPlayingRef = null;
         }
       }
     };
@@ -140,19 +147,19 @@ const RenderListItem = React.memo(
               candleHeightScale={4}
               onPlayerStateChange={state => {
                 setPlayerState(state);
-                // console.log(`state changed ${state}`);
+                console.log(`state changed ${state}`);
               }}
               onPanStateChange={onPanStateChange}
               onError={error => {
                 console.log(error, 'we are in example');
               }}
               onCurrentProgressChange={(currentProgress, songDuration) => {
-                console.log(
-                  'currentProgress ',
-                  currentProgress,
-                  'songDuration ',
-                  songDuration
-                );
+                // console.log(
+                //   'currentProgress ',
+                //   currentProgress,
+                //   'songDuration ',
+                //   songDuration
+                // );
               }}
               onChangeWaveformLoadState={state => {
                 setIsLoading(state);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -75,6 +75,11 @@ const RenderListItem = React.memo(
           finishMode: FinishMode.stop,
         });
       } else {
+        // If we are recording do nothing
+        if (currentPlayer.currentState === RecorderState.recording) {
+          return;
+        }
+
         // Always stop current player if it was playing
         if (currentPlayer.currentState === PlayerState.playing) {
           await currentPlayingRef?.current?.stopPlayer();

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -44,7 +44,7 @@ import { Colors } from './theme';
 import FastImage from 'react-native-fast-image';
 import fs from 'react-native-fs';
 
-let currentPlayingRef: React.RefObject<IWaveformRef> | null = null;
+let currentPlayingRef: React.RefObject<IWaveformRef> | undefined;
 const RenderListItem = React.memo(
   ({
     item,
@@ -63,8 +63,6 @@ const RenderListItem = React.memo(
     const [isLoading, setIsLoading] = useState(true);
 
     const handlePlayStopAction = async () => {
-      console.log('currentPlayingRef', currentPlayingRef);
-
       let currentPlayer = currentPlayingRef?.current;
 
       // If no player or if current player is stopped just start it!
@@ -82,7 +80,7 @@ const RenderListItem = React.memo(
           await currentPlayingRef?.current?.stopPlayer();
         }
 
-        // Start player only when it is a different one!
+        // Start player when it is a different one!
         if (currentPlayer.playerKey() !== ref?.current?.playerKey()) {
           currentPlayingRef = ref;
           await currentPlayingRef.current?.startPlayer({
@@ -145,21 +143,15 @@ const RenderListItem = React.memo(
               scrubColor={Colors.white}
               waveColor={Colors.lightWhite}
               candleHeightScale={4}
-              onPlayerStateChange={state => {
-                setPlayerState(state);
-                console.log(`state changed ${state}`);
-              }}
+              onPlayerStateChange={setPlayerState}
               onPanStateChange={onPanStateChange}
               onError={error => {
                 console.log(error, 'we are in example');
               }}
               onCurrentProgressChange={(currentProgress, songDuration) => {
-                // console.log(
-                //   'currentProgress ',
-                //   currentProgress,
-                //   'songDuration ',
-                //   songDuration
-                // );
+                console.log(
+                  `currentProgress ${currentProgress}, songDuration ${songDuration}`
+                );
               }}
               onChangeWaveformLoadState={state => {
                 setIsLoading(state);
@@ -226,7 +218,7 @@ const LivePlayerComponent = ({
       ref.current?.stopRecord().then(path => {
         setList(prev => [...prev, { fromCurrentUser: true, path }]);
       });
-      currentPlayingRef = null;
+      currentPlayingRef = undefined;
     }
   };
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -62,7 +62,7 @@ const RenderListItem = React.memo(
     const styles = stylesheet({ currentUser: item.fromCurrentUser });
     const [isLoading, setIsLoading] = useState(true);
 
-    const handlePlayStopAction = async () => {
+    const handlePlayPauseAction = async () => {
       let currentPlayer = currentPlayingRef?.current;
 
       // If no player or if current player is stopped just start it!
@@ -80,9 +80,9 @@ const RenderListItem = React.memo(
           return;
         }
 
-        // Always stop current player if it was playing
+        // Pause current player if it was playing
         if (currentPlayer.currentState === PlayerState.playing) {
-          await currentPlayingRef?.current?.stopPlayer();
+          await currentPlayingRef?.current?.pausePlayer();
         }
 
         // Start player when it is a different one!
@@ -95,13 +95,17 @@ const RenderListItem = React.memo(
       }
     };
 
+    const handleStopAction = async () => {
+      ref.current?.stopPlayer();
+    };
+
     return (
       <View key={item.path} style={[styles.listItemContainer]}>
         <View style={styles.listItemWidth}>
           <View style={[styles.buttonContainer]}>
             <Pressable
               disabled={isLoading}
-              onPress={handlePlayStopAction}
+              onPress={handlePlayPauseAction}
               style={styles.playBackControlPressable}>
               {isLoading ? (
                 <ActivityIndicator color={'#FFFFFF'} />

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -586,6 +586,8 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
     pauseRecord: pauseRecordingAction,
     stopRecord: stopRecordingAction,
     resumeRecord: resumeRecordingAction,
+    currentState: mode === 'static' ? playerState : recorderState,
+    playerKey: () => path,
   }));
 
   return (

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -587,7 +587,7 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
     stopRecord: stopRecordingAction,
     resumeRecord: resumeRecordingAction,
     currentState: mode === 'static' ? playerState : recorderState,
-    playerKey: () => path,
+    playerKey: path,
   }));
 
   return (

--- a/src/components/Waveform/WaveformTypes.ts
+++ b/src/components/Waveform/WaveformTypes.ts
@@ -52,5 +52,5 @@ export interface IWaveformRef {
   pauseRecord: () => Promise<boolean>;
   resumeRecord: () => Promise<boolean>;
   currentState: PlayerState | RecorderState;
-  playerKey: () => string;
+  playerKey: string;
 }

--- a/src/components/Waveform/WaveformTypes.ts
+++ b/src/components/Waveform/WaveformTypes.ts
@@ -51,4 +51,6 @@ export interface IWaveformRef {
   stopRecord: () => Promise<string>;
   pauseRecord: () => Promise<boolean>;
   resumeRecord: () => Promise<boolean>;
+  currentState: PlayerState | RecorderState;
+  playerKey: () => string;
 }


### PR DESCRIPTION
Currently, the logic of starting or stopping a player or an audio recording triggers the stop action on all the players, which is useless, and when doing so with around 40 players, we see a noticeable lag when playing one audio after another.

By adding the `playerState` and the `playerKey,` I could review the logic in the example app so that we could only stop the previous player from playing instead of all of them.

Finally, by adding the `recorderState,` I also managed to stop any player when starting a recording.

Testing Proof of the changes

https://github.com/user-attachments/assets/b2d633aa-689d-4ee2-b65d-d0561a55b281

