### PR TITLE
fix: use partial imports for lodash to reduce bundle size

### DIFF
--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -1,4 +1,8 @@
-import { clamp, floor, head, isEmpty, isNil } from 'lodash';
+import clamp from 'lodash/clamp';
+import floor from 'lodash/floor';
+import head from 'lodash/head';
+import isEmpty from 'lodash/isEmpty';
+import isNil from 'lodash/isNil';
 import React, {
   forwardRef,
   useEffect,


### PR DESCRIPTION
Using partial imports for lodash reduced bundle size of lodash package in our app from `742.4KB` to `179.5KB`. 
I have used [expo-atlas](https://expo.dev/blog/introducing-expo-atlas) to measure the bundle size changes, this can also be tested with [react-native-bundle-visualizer](https://www.npmjs.com/package/react-native-bundle-visualizer).