### PR TITLE
fix(UNT-T30512): Issue #129 Handle division by 0

### DIFF
--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -180,7 +180,7 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
         const result = await extractWaveformData({
           path: path,
           playerKey: `PlayerFor${path}`,
-          noOfSamples: noOfSample,
+          noOfSamples: Math.max(noOfSample, 1),
         });
         (onChangeWaveformLoadState as Function)?.(false);
 


### PR DESCRIPTION
- Handle division of 0 for Android with insufficient width and noOfSamples are 0.