### PR TITLE
fix(android): promises leak caused by player not in the HashMap

### DIFF
--- a/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
+++ b/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
@@ -159,13 +159,10 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
     @ReactMethod
     fun startPlayer(obj: ReadableMap, promise: Promise) {
         val finishMode = obj.getInt(Constants.finishMode)
-        val key = obj.getString(Constants.playerKey)
         val speed = obj.getDouble(Constants.speed)
-        if (key != null) {
-            audioPlayers[key]?.start(finishMode ?: 2, speed.toFloat(),promise)
-        } else {
-            promise.reject("startPlayer Error", "Player key can't be null")
-        }
+
+        val player = getPlayerOrReject(obj, promise, "startPlayer Error");
+        player?.start(finishMode ?: 2, speed.toFloat(),promise)
     }
 
     @ReactMethod
@@ -182,12 +179,8 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
 
     @ReactMethod
     fun pausePlayer(obj: ReadableMap, promise: Promise) {
-        val key = obj.getString(Constants.playerKey)
-        if (key != null) {
-            audioPlayers[key]?.pause(promise)
-        } else {
-            promise.reject("pausePlayer Error", "Player key can't be null")
-        }
+        val player = getPlayerOrReject(obj, promise, "pausePlayer Error");
+        player?.pause(promise);
     }
 
     @ReactMethod
@@ -195,12 +188,9 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val progress = obj.getInt(Constants.progress)
-                val key = obj.getString(Constants.playerKey)
-                if (key != null) {
-                    audioPlayers[key]?.seekToPosition(progress.toLong(), promise)
-                } else {
-                    promise.reject("seekTo Error", "Player key can't be null")
-                }
+
+                val player = getPlayerOrReject(obj, promise, "seekTo Error");
+                player?.seekToPosition(progress.toLong(), promise)
             } else {
                 Log.e(
                     Constants.LOG_TAG,
@@ -216,24 +206,18 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
     @ReactMethod
     fun setVolume(obj: ReadableMap, promise: Promise) {
         val volume = obj.getInt(Constants.volume)
-        val key = obj.getString(Constants.playerKey)
-        if (key != null) {
-            audioPlayers[key]?.setVolume(volume.toFloat(), promise)
-        } else {
-            promise.reject("setVolume error", "Player key can't be null")
-        }
+
+        val player = getPlayerOrReject(obj, promise, "setVolume Error");
+        player?.setVolume(volume.toFloat(), promise)
     }
 
     @ReactMethod
     fun getDuration(obj: ReadableMap, promise: Promise) {
-        val key = obj.getString(Constants.playerKey)
         val duration = obj.getInt(Constants.durationType)
         val type = if (duration == 0) DurationType.Current else DurationType.Max
-        if (key != null) {
-            audioPlayers[key]?.getDuration(type, promise)
-        } else {
-            promise.reject("getDuration Error", "Player key can't be null")
-        }
+
+        val player = getPlayerOrReject(obj, promise, "getDuration Error");
+        player?.getDuration(type, promise)
     }
 
     @ReactMethod
@@ -429,4 +413,18 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
         handler.removeCallbacks(emitLiveRecordValue)
     }
 
+    private fun getPlayerOrReject(arguments: ReadableMap, promise: Promise, errorCode: String): AudioPlayer? {
+        val key = getPlayerKeyOrReject(arguments, promise, errorCode)
+        return audioPlayers[key] ?: run {
+            promise.reject(errorCode, "$errorCode: Player not in the list")
+            null
+        }
+    }
+
+    private fun getPlayerKeyOrReject(arguments: ReadableMap, promise: Promise, errorCode: String): String? {
+        return arguments.getString(Constants.playerKey) ?: run {
+            promise.reject(errorCode, "$errorCode: Player key can't be null")
+            null
+        }
+    }
 }

--- a/src/components/Waveform/Waveform.tsx
+++ b/src/components/Waveform/Waveform.tsx
@@ -258,8 +258,10 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
           );
         }
       } catch (error) {
-        // If the player is not prepared, triggering the stop will reset the player for next click
-        await stopPlayerAction();
+        if (playerState === PlayerState.paused) {
+          // If the player is not prepared, triggering the stop will reset the player for next click. Fix blocked paused player after a call to `stopAllPlayers`
+          await stopPlayerAction();
+        }
 
         return Promise.reject(error);
       }
@@ -441,8 +443,10 @@ export const Waveform = forwardRef<IWaveformRef, IWaveform>((props, ref) => {
               progress: clampedSeekAmount * songDuration,
             });
           } catch (e) {
-            // If the player is not prepared, triggering the stop will reset the player for next click
-            await stopPlayerAction();
+            if (playerState === PlayerState.paused) {
+              // If the player is not prepared, triggering the stop will reset the player for next click. Fix blocked paused player after a call to `stopAllPlayers`
+              await stopPlayerAction();
+            }
           }
 
           if (playerState === PlayerState.playing) {


### PR DESCRIPTION
After calling `stopAllPlayers,` if we call some Android native function and the player is not in the HashMap, multiple functions will forget to reject the promise and end up with promise leaks. This is affecting `startPlayer`, `pausePlayer`, `seekToPlayer`, `setVolume`, `getDuration`

Below is an example where the console log after `await AudioWaveform.startPlayer` never shows since the call leaked the promise
STR:
- Start a player
- Pause de player
- Call `useAudioPlayer.stopAllPlayers()`
- Start the the player again
- The `useAudioPlayer.startPlayer()` never returns

<img width="897" alt="Screenshot 2024-11-16 at 1 34 30 PM" src="https://github.com/user-attachments/assets/971d0d33-0ce1-440e-90af-4e68b73adaa4">


<br>
<br>
<br>
<br>
Once the promise is rejected correctly, the error is propagated to the JS correctly, proof:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/c606b0bb-4671-4ee0-8ea9-577c52e0ffa4">

