### PR TITLE
feat: decouple useAudioRecorder hook of waveform component

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,43 @@ const ref = useRef<IWaveformRef>(null);
 />;
 ```
 
+#### 3. Use recording functions without use WaveForm Component
+
+If you want to use our library to record audio but you do not need or do not want to display a live Waveform Component while recording you can use useAudioRecorder hook to extract all necessary functions to record voice
+
+```tsx
+import { useAudioRecorder } from '@simform_solutions/react-native-audio-waveform';
+import React, { useEffect } from 'react';
+import { View, Text } from 'react-native';
+
+export default () => {
+  const {
+    recorderState,
+    getDecibel,
+    pauseRecording,
+    resumeRecording,
+    startRecording,
+    stopRecording,
+    onCurrentRecordingWaveformData,
+  } = useAudioRecorder();
+
+  useEffect(() => {
+    const audioRecordingListener = onCurrentRecordingWaveformData(result => {
+      console.log(result);
+    });
+    return () => {
+      audioRecordingListener.remove();
+    };
+  }, []);
+
+  return (
+    <View>
+      <Text>My recording voice component</Text>
+    </View>
+  );
+};
+```
+
 You can check out the full example at [Example](./example/src/App.tsx).
 
 ---

--- a/src/hooks/useAudioPlayer.tsx
+++ b/src/hooks/useAudioPlayer.tsx
@@ -7,7 +7,6 @@ import {
   type IGetDuration,
   type IOnCurrentDurationChange,
   type IOnCurrentExtractedWaveForm,
-  type IOnCurrentRecordingWaveForm,
   type IPausePlayer,
   type IPreparePlayer,
   type ISeekPlayer,
@@ -71,14 +70,6 @@ export const useAudioPlayer = () => {
       result => callback(result)
     );
 
-  const onCurrentRecordingWaveformData = (
-    callback: (result: IOnCurrentRecordingWaveForm) => void
-  ) =>
-    audioPlayerEmitter.addListener(
-      NativeEvents.onCurrentRecordingWaveformData,
-      result => callback(result)
-    );
-
   const setPlaybackSpeed = (args: ISetPlaybackSpeed) =>
     AudioWaveform.setPlaybackSpeed(args);
 
@@ -99,7 +90,6 @@ export const useAudioPlayer = () => {
     onCurrentDuration,
     onCurrentExtractedWaveformData,
     getDuration,
-    onCurrentRecordingWaveformData,
     setPlaybackSpeed,
     markPlayerAsUnmounted,
     stopAllWaveFormExtractors,

--- a/src/hooks/useAudioRecorder.tsx
+++ b/src/hooks/useAudioRecorder.tsx
@@ -1,23 +1,75 @@
+import { NativeEventEmitter, NativeModules } from 'react-native';
 import { AudioWaveform } from '../AudioWaveform';
-import type { IStartRecording } from '../types';
+import type { IOnCurrentRecordingWaveForm, IStartRecording } from '../types';
+import { NativeEvents, RecorderState } from '../constants';
+import { useState } from 'react';
+import { isEmpty, isNil } from 'lodash';
 
 export const useAudioRecorder = () => {
-  const startRecording = (args?: Partial<IStartRecording>) =>
-    AudioWaveform.startRecording(args);
+  const [recorderState, setRecorderState] = useState(RecorderState.stopped);
 
-  const stopRecording = () => AudioWaveform.stopRecording();
+  const audioPlayerEmitter = new NativeEventEmitter(
+    NativeModules.AudioWaveformsEventEmitter
+  );
 
-  const pauseRecording = () => AudioWaveform.pauseRecording();
+  const startRecording = async (args?: Partial<IStartRecording>) => {
+    const start = await AudioWaveform.startRecording(args);
+    if (!isNil(start) && start) {
+      setRecorderState(RecorderState.recording);
+      return Promise.resolve(true);
+    } else {
+      return Promise.reject(new Error('error in start recording action'));
+    }
+  };
 
-  const resumeRecording = () => AudioWaveform.resumeRecording();
+  const stopRecording = async () => {
+    const data = await AudioWaveform.stopRecording();
+    if (!isNil(data) && !isEmpty(data)) {
+      return Promise.resolve(data);
+    } else {
+      return Promise.reject(
+        new Error('error in stopping recording. can not get path of recording')
+      );
+    }
+  };
+
+  const pauseRecording = async () => {
+    const pause = await AudioWaveform.pauseRecording();
+    if (!isNil(pause) && pause) {
+      setRecorderState(RecorderState.paused);
+      return Promise.resolve(pause);
+    } else {
+      return Promise.reject(new Error('Error in pausing recording audio'));
+    }
+  };
+
+  const resumeRecording = async () => {
+    const resume = await AudioWaveform.resumeRecording();
+    if (!isNil(resume)) {
+      setRecorderState(RecorderState.recording);
+      return Promise.resolve(resume);
+    } else {
+      return Promise.reject(new Error('Error in resume recording'));
+    }
+  };
 
   const getDecibel = () => AudioWaveform.getDecibel();
 
+  const onCurrentRecordingWaveformData = (
+    callback: (result: IOnCurrentRecordingWaveForm) => void
+  ) =>
+    audioPlayerEmitter.addListener(
+      NativeEvents.onCurrentRecordingWaveformData,
+      result => callback(result)
+    );
+
   return {
+    recorderState,
     getDecibel,
     pauseRecording,
     resumeRecording,
     startRecording,
     stopRecording,
+    onCurrentRecordingWaveformData,
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,4 @@ export {
   RecorderState,
   UpdateFrequency,
 } from './constants';
-export { useAudioPermission, useAudioPlayer } from './hooks';
+export { useAudioPermission, useAudioPlayer, useAudioRecorder } from './hooks';


### PR DESCRIPTION
Closes: https://github.com/SimformSolutionsPvtLtd/react-native-audio-waveform/issues/167
Highlight:

 * First of all the hook useAudioRecorder is a hook that does not have any life cycle state, so its exported functions are "isolate" of its implementations or consumers life cycle in this case Waveform component. That fact made decouple process was easier than expected. Now, in other side, to make a good decouple was necessary to move onCurrentRecordingWaveformData listener from useAudioPlayer to useAudioRecorder and to move recorderState from Waveform component to useAudioRecorder and return this variable in hook. Those changes do not affect any already existing implementations and I made test using example app to verify everything continues working and a different test project to test use of useAudioRecorder without Waveform component and worked also. Let me know if you have any doubts  or suggestions!