### PR TITLE
fix: resolve playing audio in iOS does not have sound

### DIFF
--- a/ios/AudioPlayer.swift
+++ b/ios/AudioPlayer.swift
@@ -39,6 +39,8 @@ class AudioPlayer: NSObject, AVAudioPlayerDelegate {
       }
      
       do {
+        try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
+        try AVAudioSession.sharedInstance().setActive(true)
         player = try AVAudioPlayer(contentsOf: audioUrl!)
         player?.prepareToPlay()
         player?.volume = Float(volume ?? 100.0)


### PR DESCRIPTION
Hi! This PR fix the situtation in iOS where if user starts to play an audio it does not have volume.
It resolves next issue: https://github.com/SimformSolutionsPvtLtd/react-native-audio-waveform/issues/178