### PR TITLE
fix: react-native 0.81 build error for currentActivity and rt error on android for getDecibel func

### DIFF
--- a/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
+++ b/android/src/main/java/com/audiowaveform/AudioWaveformModule.kt
@@ -59,12 +59,12 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
 
     @ReactMethod
     fun checkHasAudioRecorderPermission(promise: Promise) {
-        audioRecorder.checkPermission(currentActivity, promise)
+        audioRecorder.checkPermission(reactApplicationContext.currentActivity, promise)
     }
 
     @ReactMethod
     fun getAudioRecorderPermission(promise: Promise) {
-        audioRecorder.getPermission(currentActivity, promise)
+        audioRecorder.getPermission(reactApplicationContext.currentActivity, promise)
     }
 
     @ReactMethod
@@ -73,8 +73,8 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
     }
 
     @ReactMethod
-    fun getDecibel(): Double? {
-        return audioRecorder.getDecibel(recorder)
+    fun getDecibel(promise: Promise) {
+        promise.resolve(audioRecorder.getDecibel(recorder))
     }
 
     @ReactMethod
@@ -379,7 +379,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
             Log.e(Constants.LOG_TAG, "Failed to initialise Recorder")
         }
         if (path == null) {
-            val outputDir = currentActivity?.cacheDir
+            val outputDir = reactApplicationContext.currentActivity?.cacheDir
             val outputFile: File?
             val dateTimeInstance = SimpleDateFormat(Constants.fileNameFormat, Locale.US)
             val currentDate = dateTimeInstance.format(Date())
@@ -413,7 +413,7 @@ class AudioWaveformModule(context: ReactApplicationContext): ReactContextBaseJav
 
     private val emitLiveRecordValue = object : Runnable {
         override fun run() {
-            val currentDecibel = getDecibel()
+            val currentDecibel = audioRecorder.getDecibel(recorder)
             val args: WritableMap = Arguments.createMap()
             if (currentDecibel == Double.NEGATIVE_INFINITY) {
                 args.putDouble(Constants.currentDecibel, 0.0)


### PR DESCRIPTION
This PR resolves react-native 0.81 build error for currentActivity and runtime error in android for getDecibel function. 

I tested this in both android and IOS. Everything is working including the live mode