### PR TITLE
fix(ios): don't mix recording with other apps' audio

### DIFF
--- a/ios/AudioRecorder.swift
+++ b/ios/AudioRecorder.swift
@@ -45,7 +45,13 @@ public class AudioRecorder: NSObject, AVAudioRecorderDelegate{
       AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
     ]
     
-    let options: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .allowBluetooth, .mixWithOthers]
+    // Don't pass .mixWithOthers when configuring an audio-recording session:
+    // mixing means other apps (Spotify, Apple Music, Podcasts, …) keep
+    // playing through the speaker while recording, and that audio bleeds
+    // straight into the recorded file via the device microphone. Starting
+    // a recording should interrupt other audio so the mic captures only the
+    // user's voice.
+    let options: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .allowBluetooth]
 
     if (path == nil) {
       guard let newPath = self.createAudioRecordPath(fileNameFormat: fileNameFormat) else {


### PR DESCRIPTION
## Summary

The AVAudioSession options passed to `setCategory(.playAndRecord, options:)` in `AudioRecorder.startRecording` currently include `.mixWithOthers`:

```swift
let options: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .allowBluetooth, .mixWithOthers]
```

`.mixWithOthers` tells AVAudioSession to let other audio apps (Spotify, Apple Music, Podcasts, system sounds, …) keep playing through the speaker for the duration of the recording. While that is the right behaviour for a *playback* session, for a *recording* session it has a nasty side effect: the device microphone picks up the speaker output and **bleeds it straight into the recorded file**. Every voice memo recorded while music is playing ends up being a mix of the user's voice and the music.

This is almost never what users want — the expected behaviour, and the behaviour every native voice-recording app on iOS implements, is that starting a recording interrupts other audio for the duration of the recording.

## Change

Drop `.mixWithOthers` from the recorder's category options:

```swift
let options: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .allowBluetooth]
```

Starting a recording now interrupts other apps' audio, the recording captures only what the microphone hears (user's voice + ambient), and the previously-playing app resumes when the recording session ends. No other code changes.

The player session (`AudioPlayer.swift`) is unrelated and not touched.

## Test plan

- [ ] Play music in Spotify (or Apple Music / Podcasts).
- [ ] Start a recording with the library.
- [ ] Confirm: other audio stops, the recorded file contains only mic input (no music in the background).
- [ ] Stop the recording — other audio resumes (standard AVAudioSession behaviour).
- [ ] Record with no other audio playing — recording still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)